### PR TITLE
you can create/join a server specifying address/port, see latency and receive entities

### DIFF
--- a/src/client/MainWindow.cc
+++ b/src/client/MainWindow.cc
@@ -1,6 +1,7 @@
 #include "MainWindow.h"
 #include <QTimer>
 #include <QDebug>
+#include <QObject>
 #include <memory>
 #include <QKeyEvent>
 #include <QtWidgets/QMainWindow>
@@ -9,31 +10,33 @@
 #include "Values.h"
 #include "easylogging++.h"
 #include "src/common/World.h"
-#include "src/common/entity/Fire.h"
-#include "src/common/entity/Block.h"
+#include "src/common/entity/Entity.h"
+#include "ServerDialog.h"
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow),
-    server_handler_(std::make_shared<ServerHandler>()),
-    timer_(std::make_shared<common::GameTimer>()),
-    world_(std::make_shared<common::World>(21, 21))
+  server_handler_(std::make_shared<ServerHandler>()),
+  timer_(std::make_shared<common::GameTimer>()),
+  game_engine_(new common::GameEngine())
 {
-	ui->setupUi(this);
-    board_ = std::unique_ptr<Board>(new Board(world_, this));
-    show();
-    timer_->StartGame();
+  ui->setupUi(this);
 
-	SetScore(-5593);
-	SetDeaths(199);
-	SetKills(2);
+  world_ = std::shared_ptr<common::World>(game_engine_->GetWorld());
+  board_ = std::unique_ptr<Board>(new Board(world_, this));
+  show();
+  timer_->StartGame();
+
+  SetScore(0);
+  SetDeaths(0);
+  SetKills(0);
 }
 
 
 void MainWindow::Start() {
-	
+
 }
 
 MainWindow::~MainWindow() {
-	delete ui;
+  delete ui;
 }
 
 
@@ -42,38 +45,79 @@ void MainWindow::Timer() {
 
 
 void MainWindow::keyPressEvent(QKeyEvent *evt) {
-    LOG(INFO) << evt->text().toStdString();
-	(void)evt;
+  LOG(INFO) << evt->text().toStdString();
+
+  if (evt->key() == Qt::Key_Down) {
+    // émettre un MoveEvent
+  }
 }
 
 void MainWindow::StartNewGame() {
-	
+
 }
 
 //int nbColumns = 15; // = background.width / block.size
 //int nbRows = 15; // = background.height / block.size
 
 void MainWindow::SetScore(float score) {
-	ui->scoreLabel->setText("Score : " + QString::number(score));
+  ui->scoreLabel->setText("Score : " + QString::number(score));
 }
 
 void MainWindow::SetDeaths(int deaths) {
-	ui->deathsLabel->setText("Deaths : " + QString::number(deaths));
+  ui->deathsLabel->setText("Deaths : " + QString::number(deaths));
 }
 
 void MainWindow::SetKills(int kills) {
-	ui->killsLabel->setText("Kills : " + QString::number(kills));
+  ui->killsLabel->setText("Kills : " + QString::number(kills));
 }
 
 void MainWindow::on_actionCreate_triggered() {
-    server_handler_->runServer();
-    network_worker_ = std::unique_ptr<net::NetworkWorker>(new net::NetworkWorker(1, QHostAddress("127.0.0.1"), 4567, 4568, timer_));
+  server_handler_->runServer();
+
+  std::istringstream iss(SERVER_PORT);
+  int port;
+  iss >> port;
+
+  InstanciateNetworkWorker("127.0.0.1", port);
+  ui->actionCreate->setEnabled(false);
+  ui->actionJoin->setEnabled(false);
 }
 
 void MainWindow::on_actionJoin_triggered() {
-    network_worker_ = std::unique_ptr<net::NetworkWorker>(new net::NetworkWorker(1, QHostAddress("127.0.0.1"), 4567, 4568, timer_));
+  ServerDialog server_dialog;
+  server_dialog.setModal(true);
+  if (server_dialog.exec()) {
+    QString address = server_dialog.GetServerAddress();
+    int port = server_dialog.GetServerPort();
+
+    LOG(INFO) << "Trying to connect on " << address.toStdString() << ":" << port << "...";
+    InstanciateNetworkWorker("127.0.0.1", port);
+
+    ui->actionCreate->setEnabled(false);
+    ui->actionJoin->setEnabled(false);
+  }
 }
 
 void MainWindow::on_actionQuit_triggered() {
-	QApplication::quit();
+  QApplication::quit();
+}
+
+void MainWindow::InstanciateNetworkWorker(QString address, int port) {
+  network_worker_ = std::unique_ptr<net::NetworkWorker>(new net::NetworkWorker(1, QHostAddress(address), port, port + 1, timer_));
+  // Ici il faudrait pouvoir connecter network_worker à un signal ServerNotRespondingPing() du worker
+  // qui se déclencherait si le serveur ne répond pas au ping, ça permet de savoir que ce serveur n'est pas (ou plus) bon
+  // et de revenir en mode non-connecté
+
+  QObject::connect(network_worker_.get(), SIGNAL(Latency(int)), this, SLOT(DisplayLatency(int)));
+  QObject::connect(network_worker_.get(), SIGNAL(EntityReceived(ServerEntity&)), this, SLOT(ProcessServerEntity(ServerEntity&)));
+}
+
+void MainWindow::DisplayLatency(int latency) {
+  ui->latencyLabel->setText("Latence : " + QString::number(latency / 1000) + "s");
+}
+
+void MainWindow::ProcessServerEntity(ServerEntity& server_entity) {
+  // Ici il faut pouvoir updater une Entity à la place de l'ajouter
+  // L'ajout de l'entité ne fonctionne d'ailleurs pas (je n'ai pas encore investigué)
+  game_engine_->AddEntity(std::unique_ptr<common::entity::Entity>(server_entity.GetEntity()));
 }

--- a/src/client/MainWindow.h
+++ b/src/client/MainWindow.h
@@ -10,7 +10,11 @@
 #include "Board.h"
 #include "ServerHandler.h"
 #include "src/common/GameTimer.h"
+#include "src/common/GameEngine.h"
 #include "net/NetworkWorker.h"
+#include "net/ServerEntity.h"
+
+using net::ServerEntity;
 
 class MainWindow : public QMainWindow
 {
@@ -19,6 +23,7 @@ class MainWindow : public QMainWindow
 public:
 	explicit MainWindow(QWidget *parent = 0);
 	~MainWindow();
+    void InstanciateNetworkWorker(QString address, int port);
 	void Start();
 
 public slots:
@@ -27,6 +32,8 @@ public slots:
 	void SetScore(float score);
 	void SetKills(int kills);
 	void SetDeaths(int deaths);
+    void DisplayLatency(int latency);
+    void ProcessServerEntity(ServerEntity& server_entity);
 
 private slots:
 	void on_actionCreate_triggered();
@@ -38,14 +45,12 @@ protected:
 
 private:
 	Ui::MainWindow *ui;
-	QLabel scoreLabel;
-	QLabel deathsLabel;
-	QLabel killsLabel;
 	std::unique_ptr<Board> board_;
     std::shared_ptr<ServerHandler> server_handler_;
     std::shared_ptr<common::GameTimer> timer_;
     std::shared_ptr<common::World> world_;
     std::unique_ptr<net::NetworkWorker> network_worker_;
+    std::unique_ptr<common::GameEngine> game_engine_;
 };
 
 #endif // SRC_CLIENT_MAINWINDOW_H

--- a/src/client/ServerDialog.cc
+++ b/src/client/ServerDialog.cc
@@ -1,0 +1,46 @@
+#include "ServerDialog.h"
+#include <QIntValidator>
+#include <QGridLayout>
+#include "easylogging++.h"
+
+ServerDialog::ServerDialog(QWidget *parent) : QDialog(parent) {
+    host_label_ = new QLabel("Server name:");
+    port_label_ = new QLabel("Server port:");
+
+    host_line_edit_ = new QLineEdit("127.0.0.1");
+    port_line_edit_ = new QLineEdit("4567");
+    port_line_edit_->setValidator(new QIntValidator(1, 65535, this));
+
+    host_label_->setBuddy(host_line_edit_);
+    port_label_->setBuddy(port_line_edit_);
+
+    ok_button_ = new QPushButton("Join");
+    ok_button_->setDefault(true);
+
+    close_button_ = new QPushButton("Cancel");
+
+    button_box_ = new QDialogButtonBox;
+    button_box_->addButton(ok_button_, QDialogButtonBox::ActionRole);
+    button_box_->addButton(close_button_, QDialogButtonBox::RejectRole);
+
+    connect(ok_button_, SIGNAL(clicked()), this, SLOT(accept()));
+    connect(close_button_, SIGNAL(clicked()), this, SLOT(reject()));
+
+    QGridLayout *mainLayout = new QGridLayout;
+    mainLayout->addWidget(host_label_, 0, 0);
+    mainLayout->addWidget(host_line_edit_, 0, 1);
+    mainLayout->addWidget(port_label_, 1, 0);
+    mainLayout->addWidget(port_line_edit_, 1, 1);
+    mainLayout->addWidget(button_box_, 2, 0, 1, 2);
+    setLayout(mainLayout);
+
+    host_line_edit_->setFocus();
+}
+
+QString ServerDialog::GetServerAddress() {
+    return host_line_edit_->text();
+}
+
+int ServerDialog::GetServerPort() {
+    return port_line_edit_->text().toInt();
+}

--- a/src/client/ServerDialog.h
+++ b/src/client/ServerDialog.h
@@ -1,0 +1,28 @@
+#ifndef SRC_CLIENT_SERVERDIALOG_H_
+#define SRC_CLIENT_SERVERDIALOG_H_
+#include <QObject>
+#include <QDialog>
+#include <QPushButton>
+#include <QLabel>
+#include <QLineEdit>
+#include <QDialogButtonBox>
+
+class ServerDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    ServerDialog(QWidget *parent = 0);
+    QString GetServerAddress();
+    int GetServerPort();
+
+private:
+    QLabel *host_label_;
+    QLabel *port_label_;
+    QLineEdit *host_line_edit_;
+    QLineEdit *port_line_edit_;
+    QPushButton *ok_button_;
+    QPushButton *close_button_;
+    QDialogButtonBox *button_box_;
+};
+
+#endif

--- a/src/client/ServerHandler.cc
+++ b/src/client/ServerHandler.cc
@@ -31,7 +31,7 @@ void ServerHandler::runServer() {
 
     QString program = SERVER_EXE;
     QStringList arguments;
-    arguments << "--port" << SERVER_PORT;
+    arguments << "--port" << SERVER_PORT << "-v";
 
     QObject::connect(server_process_.get(), SIGNAL(started()), this, SLOT(startedServer()));
     QObject::connect(server_process_.get(), SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finishedServer(int, QProcess::ExitStatus)));
@@ -79,8 +79,6 @@ bool ServerHandler::IsAlreadyRunning() {
         std::istringstream iss(line);
         int pid_number;
         iss >> pid_number;
-
-        LOG(INFO) << "pid:" << pid_number;
 
         #ifdef _WIN32
             HANDLE pss = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0);

--- a/src/client/ui_mainwindow.h
+++ b/src/client/ui_mainwindow.h
@@ -37,6 +37,7 @@ public:
     QLabel *killsLabel;
     QLabel *deathsLabel;
     QLabel *scoreLabel;
+    QLabel *latencyLabel;
     QToolBar *toolBar;
 
 	QPixmap getPixmap(QString fileName) {
@@ -81,7 +82,7 @@ public:
         centralwidget->move(0, 51);
         widget = new QWidget(centralwidget);
         widget->setObjectName(QStringLiteral("widget"));
-        widget->setGeometry(QRect(600, 10, 98, 59));
+        widget->setGeometry(QRect(600, 10, 98, 90));
         verticalLayout = new QVBoxLayout(widget);
         verticalLayout->setObjectName(QStringLiteral("verticalLayout"));
         verticalLayout->setContentsMargins(0, 0, 0, 0);
@@ -101,6 +102,11 @@ public:
         scoreLabel->setObjectName(QStringLiteral("scoreLabel"));
         scoreLabel->setMinimumSize(QSize(37, 16));
         verticalLayout->addWidget(scoreLabel);
+
+        latencyLabel = new QLabel(widget);
+        latencyLabel->setObjectName(QStringLiteral("latencyLabel"));
+        latencyLabel->setMinimumSize(QSize(60, 16));
+        verticalLayout->addWidget(latencyLabel);
 
         // Toolbar
         toolBar = new QToolBar(MainWindow);
@@ -145,6 +151,7 @@ public:
         killsLabel->setText(QApplication::translate("MainWindow", "Number of kills : ", 0));
         deathsLabel->setText(QApplication::translate("MainWindow", "Number of deaths : ", 0));
         scoreLabel->setText(QApplication::translate("MainWindow", "Score : ", 0));
+        latencyLabel->setText(QApplication::translate("MainWindow", "Latence : ?", 0));
         toolBar->setWindowTitle(QApplication::translate("MainWindow", "toolBar", 0));
     } // retranslateUi
 

--- a/src/common/GameEngine.cc
+++ b/src/common/GameEngine.cc
@@ -3,15 +3,16 @@
 #include "entity/Character.h"
 #include "entity/Bomb.h"
 #include <cassert>
+#include "easylogging++.h"
 
 namespace common {
 
-  GameEngine::GameEngine()
+GameEngine::GameEngine()
     : QObject(),
     net::GameEventVisitor(),
     max_duration_(10 * 60 * 1000), // 10 minutes
     players_(),
-    world_(new World(79, 49)),
+    world_(new World(21, 21)),
     game_timer_(),
     new_frame_timer_(new QTimer()),
     is_running_(false) {
@@ -41,17 +42,19 @@ void GameEngine::StartGame() {
 }
 
 bool GameEngine::AddEntity(std::unique_ptr<entity::Entity> e) {
-  if ( !world_->CheckCoord(e->GetPosition()) ) {
+  if (!world_->CheckCoord(e->GetPosition()) ) {
     return false;
   }
-  if ( e->IsSolid() && !world_->IsWalkable(e->GetPosition())) {
+
+  if (e->IsSolid() && !world_->IsWalkable(e->GetPosition())) {
     return false;
   }
+
   return world_->AddItem(std::move(e));
 }
 
-World* GameEngine::GetWorld() const {
-  return world_.get();
+std::shared_ptr<World> GameEngine::GetWorld() const {
+  return world_;
 }
 
 quint32 GameEngine::GetTimestamp() const {

--- a/src/common/GameEngine.h
+++ b/src/common/GameEngine.h
@@ -30,7 +30,7 @@ namespace common {
     void StartGame();
     quint32 GetTimestamp() const;
     /* Returns the number of milliseconds that have elapsed since the last time StartGame() was called. */
-    World* GetWorld() const;
+    std::shared_ptr<World> GetWorld() const;
     void AddFireFromAtoB(QPoint a, QPoint b);
 
   private slots:
@@ -52,7 +52,7 @@ namespace common {
     quint32 max_duration_; // in milliseconds
 
     std::vector<std::unique_ptr<Player> > players_;
-    std::unique_ptr<World> world_;
+    std::shared_ptr<World> world_;
 
     GameTimer game_timer_;
     std::unique_ptr<QTimer> new_frame_timer_;

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     std::vector<net::Client> clients;
     clients.push_back(client);
     auto timer = std::make_shared<common::GameTimer>();
-    auto world = std::make_shared<World>(50, 50);
+    auto world = std::make_shared<World>(21, 21);
     timer->StartGame();
     LOG(DEBUG) << "Listening on port " << port;
     net::GameNetworkWorker worker(port, timer, std::weak_ptr<World>(world), clients);


### PR DESCRIPTION
Petites remarques @vidalieh @Neki :
- actuellement on ne peut pas mettre à jour une entité dans le GameEngine, or quand on reçoit une entité du serveur, elle devrait être envoyée au GameEngine pour qu'il la mette à jour
- car si j'ai bien compris, le client envoie des MoveEvent, et le serveur renvoie des entités déplacées par exemple ? Mais dans ce cas, à quoi sert le signal MoveEventReceived sur le worker client ? Je vous avoue que j'ai essayé de regarder mais je suis un peu perdu donc une explication dans des mots simples me serait très bénéfique pour pouvoir poursuivre.
- il y a (chez moi en tout cas) un problème de performance avec le fait pour le client de recevoir toutes les 100ms 400 entités et de les traiter : ma fenêtre rame énormément :/
